### PR TITLE
create boot configuration for inventory

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,8 @@ type params struct {
 	oobShutdownTimeout           time.Duration
 	oobUsernamePrefix            string
 	oobTemporaryPasswordSecret   string
+	machineInventoryBootImage    string
+	bootConfigurationNamespace   string
 }
 
 func parseCmdLine() params {
@@ -87,6 +89,8 @@ func parseCmdLine() params {
 	pflag.Duration("oob-shutdown-timeout", 7*time.Minute, "Wait this long before issuing an immediate shutdown, if graceful shutdown has not succeeded.")
 	pflag.String("oob-username-prefix", "metal-", "OOB: Use a prefix when creating BMC users. Cannot be empty.")
 	pflag.String("oob-temporary-password-secret", "bmc-temporary-password", "OOB: Secret to store a temporary password in. Will be generated if it does not exist.")
+	pflag.String("machine-inventory-boot-image", "ghcr.io/gardenlinux/gardenlinux:latest", "Machine: boot image to run inventory.")
+	pflag.String("boot-configuration-namespace", "default", "Boot configuration namespace.")
 
 	var help bool
 	pflag.BoolVarP(&help, "help", "h", false, "Show this help message.")
@@ -126,6 +130,8 @@ func parseCmdLine() params {
 		oobShutdownTimeout:           viper.GetDuration("oob-shutdown-timeout"),
 		oobUsernamePrefix:            viper.GetString("oob-username-prefix"),
 		oobTemporaryPasswordSecret:   viper.GetString("oob-temporary-password-secret"),
+		machineInventoryBootImage:    viper.GetString("machine-inventory-boot-image"),
+		bootConfigurationNamespace:   viper.GetString("boot-configuration-namespace"),
 	}
 }
 
@@ -300,7 +306,7 @@ func main() {
 
 	if p.enableMachineController {
 		var machineReconciler *controller.MachineReconciler
-		machineReconciler, err = controller.NewMachineReconciler()
+		machineReconciler, err = controller.NewMachineReconciler(p.machineInventoryBootImage, p.bootConfigurationNamespace)
 		if err != nil {
 			log.Error(ctx, fmt.Errorf("cannot create controller: %w", err), "controller", "Machine")
 			exitCode = 1

--- a/config/crd/bases/metal.ironcore.dev_bootconfigurations.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bootconfigurations.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: bootconfigurations.metal.ironcore.dev
+spec:
+  group: metal.ironcore.dev
+  names:
+    kind: BootConfiguration
+    listKind: BootConfigurationList
+    plural: bootconfigurations
+    singular: bootconfiguration
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BootConfiguration is the Schema for the bootconfigurations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BootConfigurationSpec defines the desired state of BootConfiguration
+            properties:
+              ignitionSecretRef:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              image:
+                type: string
+              machineRef:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - ignitionSecretRef
+            - image
+            - machineRef
+            type: object
+          status:
+            description: BootConfigurationStatus defines the observed state of BootConfiguration
+            properties:
+              state:
+                enum:
+                - Ready
+                - Pending
+                - Error
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - bases/metal.ironcore.dev_inventories.yaml
 - bases/metal.ironcore.dev_aggregates.yaml
 - bases/metal.ironcore.dev_sizes.yaml
+- bases/metal.ironcore.dev_bootconfigurations.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -35,8 +35,10 @@ import (
 )
 
 const (
-	manufacturer = "Sample"
-	serialNumber = "1234"
+	manufacturer   = "Sample"
+	serialNumber   = "1234"
+	inventoryImage = "fake"
+	bootOperatorNs = "boot-operator-system"
 )
 
 var (
@@ -128,7 +130,7 @@ var _ = BeforeSuite(func() {
 	Expect(inventoryReconciler.SetupWithManager(mgr)).To(Succeed())
 
 	var machineReconciler *MachineReconciler
-	machineReconciler, err = NewMachineReconciler()
+	machineReconciler, err = NewMachineReconciler(inventoryImage, bootOperatorNs)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(machineReconciler).NotTo(BeNil())
 	Expect(machineReconciler.SetupWithManager(mgr)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
To boot machine with prepared inventory image, machine controller will create `BootConfiguration` object.
Two flags added:
- `--inventory-boot-image` to define boot image;
- `--boot-operator-namespace` to define `BootConfiguration` namespace;

When machine has state `Initial`, status of condition `Initialized` equals to `True` and has no inventory reference, then controller will create boot configuration with reference to pre-defined ignition secret reference and boot image defined by flag.
When machine is ready to be set to `Available` state - all conditions' status equals to `True` - boot configuration will be deleted.

Pre-requisites:
- ignition secret with name `"inventory-ignition"`

**Which issue(s) this PR fixes**:
Fixes #131 

**Release note**:
NONE