### PR TITLE
update bootConfiguration api

### DIFF
--- a/api/v1alpha1/bootconfiguration_types.go
+++ b/api/v1alpha1/bootconfiguration_types.go
@@ -12,7 +12,7 @@ import (
 type BootConfigurationSpec struct {
 	MachineRef *v1.LocalObjectReference `json:"machineRef"`
 
-	IgnitionSecretRef *v1.LocalObjectReference `json:"ignitionSecretRef"`
+	IgnitionSecretRef *v1.ObjectReference `json:"ignitionSecretRef"`
 
 	Image string `json:"image"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -213,7 +213,7 @@ func (in *BootConfigurationSpec) DeepCopyInto(out *BootConfigurationSpec) {
 	}
 	if in.IgnitionSecretRef != nil {
 		in, out := &in.IgnitionSecretRef, &out.IgnitionSecretRef
-		*out = new(v1.LocalObjectReference)
+		*out = new(v1.ObjectReference)
 		**out = **in
 	}
 }

--- a/client/applyconfiguration/api/v1alpha1/bootconfigurationspec.go
+++ b/client/applyconfiguration/api/v1alpha1/bootconfigurationspec.go
@@ -13,7 +13,7 @@ import (
 // with apply.
 type BootConfigurationSpecApplyConfiguration struct {
 	MachineRef        *v1.LocalObjectReference `json:"machineRef,omitempty"`
-	IgnitionSecretRef *v1.LocalObjectReference `json:"ignitionSecretRef,omitempty"`
+	IgnitionSecretRef *v1.ObjectReference      `json:"ignitionSecretRef,omitempty"`
 	Image             *string                  `json:"image,omitempty"`
 }
 
@@ -34,7 +34,7 @@ func (b *BootConfigurationSpecApplyConfiguration) WithMachineRef(value v1.LocalO
 // WithIgnitionSecretRef sets the IgnitionSecretRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the IgnitionSecretRef field is set to the value of the last call.
-func (b *BootConfigurationSpecApplyConfiguration) WithIgnitionSecretRef(value v1.LocalObjectReference) *BootConfigurationSpecApplyConfiguration {
+func (b *BootConfigurationSpecApplyConfiguration) WithIgnitionSecretRef(value v1.ObjectReference) *BootConfigurationSpecApplyConfiguration {
 	b.IgnitionSecretRef = &value
 	return b
 }

--- a/client/applyconfiguration/internal/internal.go
+++ b/client/applyconfiguration/internal/internal.go
@@ -143,7 +143,7 @@ var schemaYAML = typed.YAMLObject(`types:
     fields:
     - name: ignitionSecretRef
       type:
-        namedType: io.k8s.api.core.v1.LocalObjectReference
+        namedType: io.k8s.api.core.v1.ObjectReference
     - name: image
       type:
         scalar: string

--- a/client/openapi/zz_generated.openapi.go
+++ b/client/openapi/zz_generated.openapi.go
@@ -715,7 +715,7 @@ func schema_ironcore_dev_metal_api_v1alpha1_BootConfigurationSpec(ref common.Ref
 					},
 					"ignitionSecretRef": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
+							Ref: ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"image": {
@@ -730,7 +730,7 @@ func schema_ironcore_dev_metal_api_v1alpha1_BootConfigurationSpec(ref common.Ref
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.ObjectReference"},
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -303,7 +303,7 @@ func main() {
 
 	if p.enableMachineController {
 		var machineReconciler *controller.MachineReconciler
-		machineReconciler, err = controller.NewMachineReconciler(p.machineInventoryBootImage)
+		machineReconciler, err = controller.NewMachineReconciler(p.machineInventoryBootImage, p.systemNamespace)
 		if err != nil {
 			log.Error(ctx, fmt.Errorf("cannot create controller: %w", err), "controller", "Machine")
 			exitCode = 1

--- a/config/crd/bases/metal.ironcore.dev_bootconfigurations.yaml
+++ b/config/crd/bases/metal.ironcore.dev_bootconfigurations.yaml
@@ -48,19 +48,62 @@ spec:
             properties:
               ignitionSecretRef:
                 description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                  ObjectReference contains enough information to let you inspect or modify the referred object.
+                  ---
+                  New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                   1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                   2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                      restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                      Those cannot be well described when embedded.
+                   3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                   4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                      during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                      and the version of the actual struct is irrelevant.
+                   5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                      will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                  Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                  For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                 properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
                   name:
-                    default: ""
                     description: |-
                       Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -129,7 +129,7 @@ var _ = BeforeSuite(func() {
 	Expect(inventoryReconciler.SetupWithManager(mgr)).To(Succeed())
 
 	var machineReconciler *MachineReconciler
-	machineReconciler, err = NewMachineReconciler(inventoryImage)
+	machineReconciler, err = NewMachineReconciler(inventoryImage, ns.Name)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(machineReconciler).NotTo(BeNil())
 	Expect(machineReconciler.SetupWithManager(mgr)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
update ignitionSecretRef type from LocalObjectReference to ObjectReference, since Secrets are namespaced objects

**Release note**:
NONE